### PR TITLE
Added limit prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Vue.component('pagination', require('laravel-vue-pagination'));
 Use the component:
 
 ```html
-<pagination :data="laravelData" v-on:pagination-change-page="getResults"></pagination>
+<pagination :data="laravelData" :limit="3" v-on:pagination-change-page="getResults"></pagination>
 ```
 
 ```javascript
@@ -72,6 +72,7 @@ Vue.component('example-component', {
 
 | Name | Type | Description |
 | --- | --- | --- |
+| `limit` | Number | Limit of pages to be rendered. Default `0` (unlimited links) `-1` will hide numeric pages and leave only arrow navigation. `3` will show 3 previous and 3 next numeric pages from current page. |
 | `data` | Object | An object containing the structure of a [Laravel paginator](https://laravel.com/docs/5.3/pagination) response. See below for default value. |
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-vue-pagination",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Vue.js pagination component for Laravel paginators and Bootstrap styles",
   "author": "Gilbert Pellegrom <gilbert@pellegrom.me>",
   "homepage": "https://github.com/gilbitron/laravel-vue-pagination",

--- a/src/laravel-vue-pagination.js
+++ b/src/laravel-vue-pagination.js
@@ -15,22 +15,44 @@ module.exports = {
 					total: 0,
 				}
 			}
+		},
+		limit: {
+			type: Number,
+			default: 0
 		}
 	},
 
-	template: '<ul class="pagination" v-if="data.total > data.per_page">' +
-	'	<li v-if="data.prev_page_url">' +
-	'		<a href="#" aria-label="Previous" @click.prevent="selectPage(--data.current_page)"><span aria-hidden="true">&laquo;</span></a>' +
-	'	</li>' +
-	'	<li v-for="n in data.last_page" :class="{ \'active\': n == data.current_page }"><a href="#" @click.prevent="selectPage(n)">{{ n }}</a></li>' +
-	'	<li v-if="data.next_page_url">' +
-	'		<a href="#" aria-label="Next" @click.prevent="selectPage(++data.current_page)"><span aria-hidden="true">&raquo;</span></a>' +
-	'	</li>' +
-	'</ul>',
+	template: `
+	<ul class="pagination" v-if="data.total > data.per_page">
+		<li v-if="data.prev_page_url">
+			<a href="#" aria-label="Previous" @click.prevent="selectPage(--data.current_page)"><span aria-hidden="true">&laquo;</span></a>
+		</li>
+		<li v-for="n in getPages()" :class="{ 'active': n == data.current_page }"><a href="#" @click.prevent="selectPage(n)">{{ n }}</a></li>
+		<li v-if="data.next_page_url">
+			<a href="#" aria-label="Next" @click.prevent="selectPage(++data.current_page)"><span aria-hidden="true">&raquo;</span></a>
+		</li>
+	</ul>`,
 
 	methods: {
 		selectPage(page) {
 			this.$emit('pagination-change-page', page);
+		},
+		getPages() {
+			if (this.limit === -1) {
+				return 0;
+			}
+			
+			if (this.limit === 0) {
+				return this.data.last_page;
+			}
+
+        	let start = this.data.current_page - this.limit,
+        	    end   = this.data.current_page + this.limit + 1;
+
+        	start = start < 1 ? 1 : start;
+        	end   = end >= this.data.last_page ? this.data.last_page + 1 : end;
+          
+        	return new Array(end - start).fill().map((_,k) => k + start);
 		}
 	}
 };

--- a/src/laravel-vue-pagination.js
+++ b/src/laravel-vue-pagination.js
@@ -53,10 +53,10 @@ module.exports = {
 
         	start = start < 1 ? 1 : start;
         	end   = end >= this.data.last_page ? this.data.last_page + 1 : end;
-          
-            for (index = start; index < end; index++) { 
-            	pages.push(index);
-            }
+
+			for (index = start; index < end; index++) { 
+				pages.push(index);
+			}
 
         	return pages;
 		}

--- a/src/laravel-vue-pagination.js
+++ b/src/laravel-vue-pagination.js
@@ -54,9 +54,9 @@ module.exports = {
         	start = start < 1 ? 1 : start;
         	end   = end >= this.data.last_page ? this.data.last_page + 1 : end;
 
-			for (index = start; index < end; index++) { 
-				pages.push(index);
-			}
+        	for (index = start; index < end; index++) {
+        		pages.push(index);
+        	}
 
         	return pages;
 		}

--- a/src/laravel-vue-pagination.js
+++ b/src/laravel-vue-pagination.js
@@ -47,12 +47,18 @@ module.exports = {
 			}
 
         	let start = this.data.current_page - this.limit,
-        	    end   = this.data.current_page + this.limit + 1;
+        	    end   = this.data.current_page + this.limit + 1,
+        	    pages = [],
+        	    index;
 
         	start = start < 1 ? 1 : start;
         	end   = end >= this.data.last_page ? this.data.last_page + 1 : end;
           
-        	return new Array(end - start).fill().map((_,k) => k + start);
+            for (index = start; index < end; index++) { 
+            	pages.push(index);
+            }
+
+        	return pages;
 		}
 	}
 };

--- a/test/laravel-vue-pagination.spec.js
+++ b/test/laravel-vue-pagination.spec.js
@@ -14,14 +14,20 @@ var exampleData = {
 		{ id: 3 },
 		{ id: 4 },
 		{ id: 5 },
+		{ id: 6 },
+		{ id: 7 },
+		{ id: 8 },
+		{ id: 9 },
+		{ id: 10 },
+		{ id: 11 },
 	],
 	from: 1,
-	last_page: 3,
+	last_page: 6,
 	next_page_url: 'http://example.com/page/2',
 	per_page: 2,
 	prev_page_url: null,
 	to: 3,
-	total: 5,
+	total: 11,
 };
 
 describe('LaravelVuePagination', function() {
@@ -31,20 +37,35 @@ describe('LaravelVuePagination', function() {
 		});
 
 		expect(vm.$el.nodeName).toBe('UL');
-		expect(vm.$el.getElementsByTagName('li').length).toBe(4);
+		expect(vm.$el.getElementsByTagName('li').length).toBe(7);
 		expect(vm.$el.getElementsByTagName('li')[0].classList).toContain('active');
+	});
+
+	it('has correct DOM structure with 1 link limit on page 3', function() {
+		exampleData.current_page = 3;
+		exampleData.next_page_url = 'http://example.com/page/4';
+		exampleData.prev_page_url = 'http://example.com/page/2';
+
+		const vm = getComponent(LaravelVuePagination, {
+			data: exampleData,
+			limit: 1
+		});
+
+		expect(vm.$el.nodeName).toBe('UL');
+		expect(vm.$el.getElementsByTagName('li').length).toBe(5);
+		expect(vm.$el.getElementsByTagName('li')[2].classList).toContain('active');
 	});
 
 	it('has correct DOM structure when on page 2', function() {
 		exampleData.current_page = 2;
-		exampleData.next_page_url = 'http://example.com/page/1';
-		exampleData.prev_page_url = 'http://example.com/page/3';
+		exampleData.next_page_url = 'http://example.com/page/3';
+		exampleData.prev_page_url = 'http://example.com/page/1';
 
 		const vm = getComponent(LaravelVuePagination, {
 			data: exampleData
 		});
 
-		expect(vm.$el.getElementsByTagName('li').length).toBe(5);
+		expect(vm.$el.getElementsByTagName('li').length).toBe(8);
 		expect(vm.$el.getElementsByTagName('li')[2].classList).toContain('active');
 	});
 


### PR DESCRIPTION
Changing `limit` property will limit number of numeric pages rendered.

Examples:

Default `0` will work as before.
<img width="332" alt="screen shot 2017-01-06 at 21 38 50" src="https://cloud.githubusercontent.com/assets/3680162/21732286/1e30d296-d459-11e6-8e67-d823866a9ff1.png">

Set to `-1` will show only arrow navigation.
<img width="112" alt="screen shot 2017-01-06 at 21 38 05" src="https://cloud.githubusercontent.com/assets/3680162/21732264/fc09be4e-d458-11e6-804d-2c4df453ee82.png">

Set to `2` will show 2 next and previous links from current page.
<img width="253" alt="screen shot 2017-01-06 at 21 39 01" src="https://cloud.githubusercontent.com/assets/3680162/21732278/11d0d028-d459-11e6-9213-67eb0827fdb1.png">
