### PR TITLE
Add range support

### DIFF
--- a/src/laravel-vue-pagination.js
+++ b/src/laravel-vue-pagination.js
@@ -34,6 +34,10 @@ module.exports = {
 
 	methods: {
 		selectPage: function(page) {
+			if (page === '...') {
+				return;
+			}
+
 			this.$emit('pagination-change-page', page);
 		},
 		getPages: function() {
@@ -45,16 +49,31 @@ module.exports = {
 				return this.data.last_page;
 			}
 
-			var start = this.data.current_page - this.limit,
-				end   = this.data.current_page + this.limit + 1,
+			var current = this.data.current_page,
+				last = this.data.last_page,
+				delta = this.limit,
+				left = current - delta,
+				right = current + delta + 1,
+				range = [],
 				pages = [],
-				index;
+				l;
 
-			start = start < 1 ? 1 : start;
-			end   = end >= this.data.last_page ? this.data.last_page + 1 : end;
+			for (var i = 1; i <= last; i++) {
+				if (i == 1 || i == last || (i >= left && i < right)) {
+					range.push(i);
+				}
+			}
 
-			for (index = start; index < end; index++) {
-				pages.push(index);
+			for (var i of range) {
+				if (l) {
+					if (i - l === 2) {
+						pages.push(l + 1);
+					} else if (i - l !== 1) {
+						pages.push('...');
+					}
+				}
+				pages.push(i);
+				l = i;
 			}
 
 			return pages;

--- a/tests/laravel-vue-pagination.js
+++ b/tests/laravel-vue-pagination.js
@@ -41,10 +41,26 @@ describe('LaravelVuePagination', function() {
 		expect(vm.$el.getElementsByTagName('li')[0].classList).toContain('active');
 	});
 
-	it('has correct DOM structure with 1 link limit on page 3', function() {
-		exampleData.current_page = 3;
-		exampleData.next_page_url = 'http://example.com/page/4';
-		exampleData.prev_page_url = 'http://example.com/page/2';
+	it('has correct DOM structure with -1 limit on page 2', function() {
+		exampleData.current_page = 2;
+		exampleData.next_page_url = 'http://example.com/page/3';
+		exampleData.prev_page_url = 'http://example.com/page/1';
+
+		const vm = getComponent(LaravelVuePagination, {
+			data: exampleData,
+			limit: -1
+		});
+
+		expect(vm.$el.nodeName).toBe('UL');
+		expect(vm.$el.getElementsByTagName('li').length).toBe(2);
+	});
+
+	it('has correct DOM structure with 1 link limit on page 5', function() {
+		exampleData.current_page = 5;
+		exampleData.last_page = 11;
+		exampleData.per_page = 1;
+		exampleData.next_page_url = 'http://example.com/page/6';
+		exampleData.prev_page_url = 'http://example.com/page/4';
 
 		const vm = getComponent(LaravelVuePagination, {
 			data: exampleData,
@@ -52,12 +68,14 @@ describe('LaravelVuePagination', function() {
 		});
 
 		expect(vm.$el.nodeName).toBe('UL');
-		expect(vm.$el.getElementsByTagName('li').length).toBe(5);
-		expect(vm.$el.getElementsByTagName('li')[2].classList).toContain('active');
+		expect(vm.$el.getElementsByTagName('li').length).toBe(9);
+		expect(vm.$el.getElementsByTagName('li')[4].classList).toContain('active');
 	});
 
 	it('has correct DOM structure when on page 2', function() {
 		exampleData.current_page = 2;
+		exampleData.last_page = 6;
+		exampleData.per_page = 2;
 		exampleData.next_page_url = 'http://example.com/page/3';
 		exampleData.prev_page_url = 'http://example.com/page/1';
 


### PR DESCRIPTION
Requested in #10 

The `limit` prop now defines how many pages should be shown on either side of the current page when only a range of pages are shown. For example, a limit of 2 would now look like:

![screen shot 2018-01-12 at 4 47 50 pm](https://user-images.githubusercontent.com/203882/34885624-8001513e-f7b8-11e7-9922-236e2b07caa0.png)
