### PR TITLE
Allow to run with vue/compat build

### DIFF
--- a/src/LaravelVuePagination.vue
+++ b/src/LaravelVuePagination.vue
@@ -52,6 +52,10 @@
 import RenderlessLaravelVuePagination from './RenderlessLaravelVuePagination.vue';
 
 export default {
+    compatConfig: {
+      MODE: 3
+    },
+
     inheritAttrs: false,
 
     emits: ['pagination-change-page'],

--- a/src/RenderlessLaravelVuePagination.vue
+++ b/src/RenderlessLaravelVuePagination.vue
@@ -1,5 +1,9 @@
 <script>
 export default {
+    compatConfig: {
+      MODE: 3
+    },
+
     emits: ['pagination-change-page'],
 
     props: {


### PR DESCRIPTION
Hi @gilbitron

Most of developers would be using `@vue/compat`  to migrate their codebase to vue 3.
But this package is not working with `@vue/compat`, and crash on render.

I have added the compact config to tell the compiler that this package is using vue 3 syntax already, and compiler wont patch this component for vue 3.

https://v3-migration.vuejs.org/migration-build.html#per-component-config

Please merge and release new a version. 
This will be great help in migrating.
Thanks.